### PR TITLE
For PostLog, change the Platform Target to Any CPU instead of x86.

### DIFF
--- a/PostLog.sln
+++ b/PostLog.sln
@@ -1,6 +1,8 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PostLog", "src\PostLog\PostLog.csproj", "{A02B3BCD-DE8D-4A41-8771-8F6E010A1ECE}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PostLog.Tests", "src\PostLog.Tests\PostLog.Tests.csproj", "{4BB11B2E-A48C-4D2B-ACC2-C910EF482BC4}"
@@ -17,7 +19,7 @@ Global
 		{A02B3BCD-DE8D-4A41-8771-8F6E010A1ECE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A02B3BCD-DE8D-4A41-8771-8F6E010A1ECE}.Debug|x86.ActiveCfg = Debug|x86
 		{A02B3BCD-DE8D-4A41-8771-8F6E010A1ECE}.Debug|x86.Build.0 = Debug|x86
-		{A02B3BCD-DE8D-4A41-8771-8F6E010A1ECE}.Release|Any CPU.ActiveCfg = Release|x86
+		{A02B3BCD-DE8D-4A41-8771-8F6E010A1ECE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A02B3BCD-DE8D-4A41-8771-8F6E010A1ECE}.Release|x86.ActiveCfg = Release|x86
 		{A02B3BCD-DE8D-4A41-8771-8F6E010A1ECE}.Release|x86.Build.0 = Release|x86
 		{4BB11B2E-A48C-4D2B-ACC2-C910EF482BC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU


### PR DESCRIPTION
Without it the application that use PostLog will get build warning:

There was a mismatch between the processor architecture of the project
being built "MSIL" and the processor architecture of the reference
"PostLog", "x86". This mismatch may cause runtime failures.